### PR TITLE
cursor rework and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,76 +66,76 @@ func (df *PersonFactory) NewEdge() apicursor.Edge {
 
 type PersonConnection struct {
 	// A list of edges.
-	edges []*PersonEdge
+	Edges []*PersonEdge
 	// A list of nodes.
-	nodes []*Person
+	Nodes []*Person
 	// Information to aid in pagination.
-	pageInfo *apicursor.PageInfo
+	PageInfo *apicursor.PageInfo
 	// Identifies the total count of items in the connection.
-	totalCount uint64
+	TotalCount uint64
 }
 
 func (dc *PersonConnection) GetEdges() []*PersonEdge {
-	return dc.edges
+	return dc.Edges
 }
 
 func (dc *PersonConnection) SetEdges(edges []apicursor.Edge) {
-	dc.edges = make([]*PersonEdge, len(edges))
+	dc.Edges = make([]*PersonEdge, len(edges))
 	for i, d := range edges {
 		de := d.(*PersonEdge)
-		dc.edges[i] = de
+		dc.Edges[i] = de
 	}
 }
 
 func (dc *PersonConnection) GetNodes() []*Person {
-	return dc.nodes
+	return dc.Nodes
 }
 
 func (dc *PersonConnection) SetNodes(nodes []interface{}) {
-	dc.nodes = make([]*Person, len(nodes))
+	dc.Nodes = make([]*Person, len(nodes))
 	for i, d := range nodes {
 		dev := d.(*Person)
-		dc.nodes[i] = dev
+		dc.Nodes[i] = dev
 	}
 }
 
 func (dc *PersonConnection) GetPageInfo() *apicursor.PageInfo {
-	return dc.pageInfo
+	return dc.PageInfo
 }
 
 func (dc *PersonConnection) SetPageInfo(pginfo *apicursor.PageInfo) {
-	dc.pageInfo = pginfo
+	dc.PageInfo = pginfo
 }
 
 func (dc *PersonConnection) GetTotalCount() uint64 {
-	return dc.totalCount
+	return dc.TotalCount
 }
 
 func (dc *PersonConnection) SetTotalCount(count uint64) {
-	dc.totalCount = count
+	dc.TotalCount = count
 }
 
 type PersonEdge struct {
 	// A cursor for use in pagination.
-	cursor string
+	Cursor string
 	// The item at the end of the edge.
-	node *Person
+	Node *Person
 }
 
 func (de *PersonEdge) GetCursor() string {
-	return de.cursor
+	return de.Cursor
 }
 
 func (de *PersonEdge) SetCursor(c string) {
-	de.cursor = c
+	de.Cursor = c
 }
 
 func (de *PersonEdge) GetNode() interface{} {
-	return de.node
+	return de.Node
 }
 
 func (de *PersonEdge) SetNode(node interface{}) {
-	de.node = node.(*Person)
+	de.Node = node.(*Person)
 }
 
 // PersonOrder Ordering options for Person connections

--- a/cursor.go
+++ b/cursor.go
@@ -346,8 +346,7 @@ func (c *cursor) LoadFromAPIRequest(after *string, before *string, first *int, l
 		c.requestParams.first = &newFirst
 	}
 
-	// only use after if first is specified
-	if c.requestParams.first != nil && after != nil && len(*after) > 0 {
+	if after != nil && len(*after) > 0 {
 		var cursorBytes []byte
 		cursorBytes, err = base64.URLEncoding.DecodeString(*after)
 		if err != nil {
@@ -363,7 +362,7 @@ func (c *cursor) LoadFromAPIRequest(after *string, before *string, first *int, l
 		}
 
 		c.requestParams.after = &cursorStr
-	} else if c.requestParams.last != nil && before != nil && len(*before) > 0 {
+	} else if before != nil && len(*before) > 0 {
 		var cursorBytes []byte
 		cursorBytes, err = base64.URLEncoding.DecodeString(*before)
 		if err != nil {

--- a/cursor.go
+++ b/cursor.go
@@ -455,9 +455,17 @@ func (c *cursor) isBefore() bool {
 	return len(c.before) > 0
 }
 
+func (c *cursor) isFirst() bool {
+	return c.requestParams.first != nil && *c.requestParams.first > 0
+}
+
+func (c *cursor) isLast() bool {
+	return c.requestParams.last != nil && *c.requestParams.last > 0
+}
+
 func (c *cursor) isForward() bool {
 	//if before is set, or after is not set and last is set, then going backwards
-	if c.isBefore() || (!c.isAfter() && (c.requestParams.last != nil && *c.requestParams.last > 0)) {
+	if c.isBefore() || (!c.isAfter() && c.isLast()) {
 		return false
 	}
 	return true
@@ -482,9 +490,9 @@ func scrubLimit(newLimit int) (scrubbed int32) {
 }
 
 func (c *cursor) limit() int32 {
-	if c.requestParams.first != nil {
+	if c.isFirst() {
 		return *c.requestParams.first
-	} else if c.requestParams.last != nil {
+	} else if c.isLast() {
 		return *c.requestParams.last
 	}
 	return DefaultLimit

--- a/cursor.go
+++ b/cursor.go
@@ -219,23 +219,7 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 	// decorate all the Edges with a cursor which is the cursor to supply to an after argument to start a page at this Edge.
 	newEdgeCursor := newCursor()
 
-	//// first edge is special case if we are paging forward
-	//// if the cursor supplied by caller to query had an after then we are not at the beginning of the Connection
-	//if len(edges) > 0 && c.isForward() {
-	//	if c.isAfter() {
-	//		newEdgeCursor.after = c.after
-	//	} else {
-	//		// we are at first item of first page so after = ""
-	//	}
-	//	var edgeCursrStr string
-	//	edgeCursrStr, err = newEdgeCursor.AfterCursor()
-	//	if err != nil {
-	//		return
-	//	}
-	//	edges[0].SetCursor(edgeCursrStr)
-	//}
-
-	// add cursors to all of the edges
+	// add cursors to all the edges
 	for i := 0; i < len(edges); i++ {
 		newEdgeCursor = newCursor()
 		var cursorFields map[string]string
@@ -282,8 +266,7 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 	connection.SetPageInfo(pageInfo)
 
 	if len(edges) > 0 {
-
-		//if pageInfo.HasNextPage {
+		//set AfterCursor
 		var endCursorFields map[string]string
 		var endCursorStr string
 		newAfterCursor := newCursor()
@@ -297,9 +280,8 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 			return
 		}
 		pageInfo.EndCursor = &endCursorStr
-		//}
 
-		//if c.isAfter() || (!c.isForward() && pageInfo.HasPreviousPage) {
+		//set BeforeCursor
 		var startCursorFields map[string]string
 		var startCursorStr string
 		newBeforeCursor := newCursor()
@@ -313,8 +295,6 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 			return
 		}
 		pageInfo.StartCursor = &startCursorStr
-		//pageInfo.HasPreviousPage = true
-		//}
 	}
 
 	return

--- a/cursor.go
+++ b/cursor.go
@@ -266,7 +266,7 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 	connection.SetPageInfo(pageInfo)
 
 	if len(edges) > 0 {
-		//set AfterCursor
+		//set EndCursor
 		var endCursorFields map[string]string
 		var endCursorStr string
 		newAfterCursor := newCursor()
@@ -281,7 +281,7 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 		}
 		pageInfo.EndCursor = &endCursorStr
 
-		//set BeforeCursor
+		//set StartCursor
 		var startCursorFields map[string]string
 		var startCursorStr string
 		newBeforeCursor := newCursor()
@@ -429,8 +429,6 @@ func (c *cursor) SetStringCursorFilter(findFilter bson.M, fieldName string, natu
 		// if no cursor specified do nothing and that's ok
 		return
 	}
-	// Note: If we have a cursor it should be a valid one so error after here
-
 	if fieldValue, ok := cursorValues[fieldName]; ok {
 		findFilter[fieldName] = bson.D{{c.cursorFilterOperator(naturalSortDirection), fieldValue}}
 	} else {
@@ -458,10 +456,8 @@ func (c *cursor) isBefore() bool {
 }
 
 func (c *cursor) isForward() bool {
-	if c.isAfter() || (c.requestParams.first != nil && *c.requestParams.first > 0) {
-		return true
-	}
-	if c.isBefore() || (c.requestParams.last != nil && *c.requestParams.last > 0) {
+	//if before is set, or after is not set and last is set, then going backwards
+	if c.isBefore() || (!c.isAfter() && (c.requestParams.last != nil && *c.requestParams.last > 0)) {
 		return false
 	}
 	return true

--- a/cursor.go
+++ b/cursor.go
@@ -343,7 +343,7 @@ func (c *cursor) LoadFromAPIRequest(after *string, before *string, first *int, l
 		}
 
 		c.requestParams.after = &cursorStr
-		// only use before if first is specified
+		// only use before if last is specified
 	} else if c.isLast() && before != nil && len(*before) > 0 {
 		var cursorBytes []byte
 		cursorBytes, err = base64.URLEncoding.DecodeString(*before)

--- a/cursor.go
+++ b/cursor.go
@@ -219,27 +219,27 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 	// decorate all the Edges with a cursor which is the cursor to supply to an after argument to start a page at this Edge.
 	newEdgeCursor := newCursor()
 
-	// first edge is special case if we are paging forward
-	// if the cursor supplied by caller to query had an after then we are not at the beginning of the Connection
-	if len(edges) > 0 && c.isForward() {
-		if c.isAfter() {
-			newEdgeCursor.after = c.after
-		} else {
-			// we are at first item of first page so after = ""
-		}
-		var edgeCursrStr string
-		edgeCursrStr, err = newEdgeCursor.AfterCursor()
-		if err != nil {
-			return
-		}
-		edges[0].SetCursor(edgeCursrStr)
-	}
+	//// first edge is special case if we are paging forward
+	//// if the cursor supplied by caller to query had an after then we are not at the beginning of the Connection
+	//if len(edges) > 0 && c.isForward() {
+	//	if c.isAfter() {
+	//		newEdgeCursor.after = c.after
+	//	} else {
+	//		// we are at first item of first page so after = ""
+	//	}
+	//	var edgeCursrStr string
+	//	edgeCursrStr, err = newEdgeCursor.AfterCursor()
+	//	if err != nil {
+	//		return
+	//	}
+	//	edges[0].SetCursor(edgeCursrStr)
+	//}
 
 	// add cursors to all of the edges
-	for i := 1; i < len(edges); i++ {
+	for i := 0; i < len(edges); i++ {
 		newEdgeCursor = newCursor()
 		var cursorFields map[string]string
-		cursorFields, err = c.cursorMarshaler.Marshal(edges[i-1].GetNode())
+		cursorFields, err = c.cursorMarshaler.Marshal(edges[i].GetNode())
 		if err != nil {
 			return
 		}
@@ -282,38 +282,39 @@ func (c *cursor) ConnectionFromMongoCursor(ctx context.Context, mongoCursor *mon
 	connection.SetPageInfo(pageInfo)
 
 	if len(edges) > 0 {
-		if pageInfo.HasNextPage {
-			newAfterCursor := newCursor()
-			var cursorFields map[string]string
-			cursorFields, err = c.cursorMarshaler.Marshal(edges[len(edges)-1].GetNode())
-			if err != nil {
-				return
-			}
-			newAfterCursor.after = cursorFields
-			var edgeCursrStr string
-			edgeCursrStr, err = newEdgeCursor.AfterCursor()
-			if err != nil {
-				return
-			}
-			pageInfo.EndCursor = &edgeCursrStr
-		}
 
-		if c.isAfter() || (!c.isForward() && pageInfo.HasPreviousPage) {
-			newBeforeCursor := newCursor()
-			var cursorFields map[string]string
-			cursorFields, err = c.cursorMarshaler.Marshal(edges[0].GetNode())
-			if err != nil {
-				return
-			}
-			newBeforeCursor.before = cursorFields
-			var edgeCursrStr string
-			edgeCursrStr, err = newBeforeCursor.BeforeCursor()
-			if err != nil {
-				return
-			}
-			pageInfo.StartCursor = &edgeCursrStr
-			pageInfo.HasPreviousPage = true
+		//if pageInfo.HasNextPage {
+		var endCursorFields map[string]string
+		var endCursorStr string
+		newAfterCursor := newCursor()
+		endCursorFields, err = c.cursorMarshaler.Marshal(edges[len(edges)-1].GetNode())
+		if err != nil {
+			return
 		}
+		newAfterCursor.after = endCursorFields
+		endCursorStr, err = newAfterCursor.AfterCursor()
+		if err != nil {
+			return
+		}
+		pageInfo.EndCursor = &endCursorStr
+		//}
+
+		//if c.isAfter() || (!c.isForward() && pageInfo.HasPreviousPage) {
+		var startCursorFields map[string]string
+		var startCursorStr string
+		newBeforeCursor := newCursor()
+		startCursorFields, err = c.cursorMarshaler.Marshal(edges[0].GetNode())
+		if err != nil {
+			return
+		}
+		newBeforeCursor.before = startCursorFields
+		startCursorStr, err = newBeforeCursor.BeforeCursor()
+		if err != nil {
+			return
+		}
+		pageInfo.StartCursor = &startCursorStr
+		//pageInfo.HasPreviousPage = true
+		//}
 	}
 
 	return

--- a/pageinfo.go
+++ b/pageinfo.go
@@ -19,48 +19,42 @@ package apicursor
 
 type PageInfo struct {
 	// When paginating forwards, the cursor to continue.
-	EndCursor *string `json:"endCursor"`
+	EndCursor *string `json:"end_cursor"`
 
 	// When paginating forwards, are there more items?
-	HasNextPage bool `json:"hasNextPage"`
+	HasNextPage bool `json:"has_next_page"`
 
 	// When paginating backwards, are there more items?
-	HasPreviousPage bool `json:"hasPreviousPage"`
+	HasPreviousPage bool `json:"has_previous_page"`
 
 	// When paginating backwards, the cursor to continue.
-	StartCursor *string `json:"startCursor"`
+	StartCursor *string `json:"start_cursor"`
 }
 
 // Connection implements paging according to spec: https://relay.dev/graphql/connections.htm
 type Connection interface {
-	//// Edges returns a list of Edges on the current page.
-	//Edges() []Edge
-
 	// SetEdges sets the edges on the current page.
 	SetEdges(edges []Edge)
-
-	//// Nodes returns a list of nodes on the current page.
-	//Nodes() []interface{}
 
 	// SetNodes sets the nodes for the current page.
 	SetNodes(nodes []interface{})
 
-	// PageInfo returns the PageInfo
-	PageInfo() *PageInfo
+	// GetPageInfo returns the PageInfo
+	GetPageInfo() *PageInfo
 
 	// SetPageInfo sets the PageInfo
 	SetPageInfo(pginfo *PageInfo)
 
-	// TotalCount returns the total count of nodes in the connection (count of all nodes matching the query in all pages).
-	TotalCount() uint64
+	// GetTotalCount returns the total count of nodes in the connection (count of all nodes matching the query in all pages).
+	GetTotalCount() uint64
 
 	// SetTotalCount sets the TotalCount.
 	SetTotalCount(count uint64)
 }
 
 type Edge interface {
-	// Cursor returns the after cursor to load cursor starting at this Edge.
-	Cursor() string
+	// GetCursor returns the after cursor to load cursor starting at this Edge.
+	GetCursor() string
 
 	// SetCursor sets the cursor
 	SetCursor(c string)


### PR DESCRIPTION
* Add support for SetStringCursorFilter
* Update README example with `$or` logic in `UnmarshalMongo` and new `Get` methods to allow exported fields in the types for JSON rendering.
* Update `PageInfo` struct to use underscore for JSON tags
* Cursors are now being generated based off the current edge, instead of previous edge
* Start and End cursors are now always returned, unless edges are empty
* Fix typo bug related to EndCursor generation

I originally started working on "`after` is no longer limited to only `first` requests, `before` is no longer limited to only `last` requests" but ran out of time, so I backed out the related changes from this PR.